### PR TITLE
Fix PHP 8.4 compatibility issues

### DIFF
--- a/Model/ResourceModel/Reservation/Collection.php
+++ b/Model/ResourceModel/Reservation/Collection.php
@@ -19,17 +19,17 @@ class Collection extends AbstractCollection implements SearchResultInterface
     /**
      * @var AggregationInterface|null
      */
-    private ?AggregationInterface $_aggregations = null;
+    protected ?AggregationInterface $_aggregations = null;
 
     /**
      * @var SearchCriteriaInterface|null
      */
-    private ?SearchCriteriaInterface $searchCriteria;
+    protected ?SearchCriteriaInterface $searchCriteria;
 
     /**
      * List of fields to fulltext search
      */
-    private const FIELDS_TO_FULLTEXT_SEARCH = [
+    protected const FIELDS_TO_FULLTEXT_SEARCH = [
         'sku',
         'quantity',
         'metadata'
@@ -113,7 +113,7 @@ class Collection extends AbstractCollection implements SearchResultInterface
      */
     public function setItems(?array $items = null): Collection
     {
-        $this->_setItems($items);
+        $this->_setItems($items ?? []);
         return $this;
     }
 


### PR DESCRIPTION
## Summary

Fix PHP 8.4 compatibility issue in Collection.php:

- **setItems()**: pass empty array fallback instead of null to _setItems() preventing TypeError when called with null argument
- Change private properties and constants to protected for extensibility (_aggregations, searchCriteria, FIELDS_TO_FULLTEXT_SEARCH)

## Suggested release

@rhoerr This could be tagged as 1.0.4 (patch release).