### PR TITLE
Fix PHP 8.5 compatibility issues

### DIFF
--- a/Model/ResourceModel/Reservation/Collection.php
+++ b/Model/ResourceModel/Reservation/Collection.php
@@ -24,7 +24,7 @@ class Collection extends AbstractCollection implements SearchResultInterface
     /**
      * @var SearchCriteriaInterface|null
      */
-    protected ?SearchCriteriaInterface $searchCriteria;
+    protected ?SearchCriteriaInterface $searchCriteria = null;
 
     /**
      * List of fields to fulltext search
@@ -52,7 +52,7 @@ class Collection extends AbstractCollection implements SearchResultInterface
     }
 
     /**
-     * @param $aggregations
+     * @param AggregationInterface $aggregations
      * @return $this
      */
     public function setAggregations($aggregations): Collection
@@ -90,7 +90,7 @@ class Collection extends AbstractCollection implements SearchResultInterface
     }
 
     /**
-     * @param $totalCount
+     * @param int $totalCount
      * @return $this
      */
     public function setTotalCount($totalCount): Collection

--- a/Ui/Component/Reservation/DeleteMassAction.php
+++ b/Ui/Component/Reservation/DeleteMassAction.php
@@ -14,6 +14,11 @@ use MageOS\InventoryReservationsGrid\Api\ReservationDeletionValidatorInterface;
 class DeleteMassAction extends MassAction
 {
     /**
+     * @var ReservationDeletionValidatorInterface
+     */
+    protected ReservationDeletionValidatorInterface $validator;
+
+    /**
      * @param ContextInterface $context
      * @param ReservationDeletionValidatorInterface $validator
      * @param array $components

--- a/Ui/Component/Reservation/DeleteMassAction.php
+++ b/Ui/Component/Reservation/DeleteMassAction.php
@@ -14,11 +14,6 @@ use MageOS\InventoryReservationsGrid\Api\ReservationDeletionValidatorInterface;
 class DeleteMassAction extends MassAction
 {
     /**
-     * @var ReservationDeletionValidatorInterface
-     */
-    protected ReservationDeletionValidatorInterface $validator;
-
-    /**
      * @param ContextInterface $context
      * @param ReservationDeletionValidatorInterface $validator
      * @param array $components
@@ -26,11 +21,10 @@ class DeleteMassAction extends MassAction
      */
     public function __construct(
         ContextInterface $context,
-        ReservationDeletionValidatorInterface $validator,
+        protected ReservationDeletionValidatorInterface $validator,
         array $components = [],
         array $data = []
     ) {
-        $this->validator = $validator;
         parent::__construct($context, $components, $data);
     }
 


### PR DESCRIPTION
## Summary

Prepares the module for PHP 8.5 while keeping PHP 8.4 compatibility.

### Changes

- **`Ui/Component/Reservation/DeleteMassAction.php`**: declare explicit typed property `protected ReservationDeletionValidatorInterface $validator`. Previously it was assigned as a dynamic property in the constructor, which emits a deprecation notice under PHP 8.2+ and will become an error in future versions (the parent `Magento\Ui\Component\MassAction` does not use `#[AllowDynamicProperties]`).
- **`Model/ResourceModel/Reservation/Collection.php`**: initialize `$searchCriteria` to `null`. An uninitialized typed property raises `Error: typed property must not be accessed before initialization` when `getSearchCriteria()` is called before `setSearchCriteria()`. This is the safe default for nullable typed properties under strict runtime semantics enforced in newer PHP versions.
- **`Model/ResourceModel/Reservation/Collection.php`**: fill in missing `@param` types in PHPDoc for `setAggregations()` and `setTotalCount()` (docblock-only; signatures stay untyped to preserve covariance with the untyped `SearchResultInterface`).

### Notes

No runtime behavior change. Fixes are minimal and backward compatible with PHP 8.1+.

### Suggested release

Patch release `1.0.5`.

cc @rhoerr
